### PR TITLE
Adds role to setup capistrano deployment dirs

### DIFF
--- a/openvault/openvault.yml
+++ b/openvault/openvault.yml
@@ -8,3 +8,9 @@
   roles:
     - httpd
     - geerlingguy.ruby
+    - crushlovely.capistrano
+    
+  vars:
+    app_path: /var/www/openvault
+    app_user: ec2-user
+    app_group: ec2-user

--- a/roles/crushlovely.capistrano/.gitignore
+++ b/roles/crushlovely.capistrano/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+._*
+.Spotlight-V100
+.Trashes
+test

--- a/roles/crushlovely.capistrano/README.md
+++ b/roles/crushlovely.capistrano/README.md
@@ -1,0 +1,39 @@
+# Ansible Role For Capistrano Base Directories
+
+[![Build Status](https://circleci.com/gh/crushlovely/ansible-capistrano.svg?style=shield)](https://github.com/crushlovely/ansible-capistrano)
+[![Current Version](http://img.shields.io/github/release/crushlovely/ansible-capistrano.svg?style=flat)](https://galaxy.ansible.com/list#/roles/2370)
+
+This Ansible role creates the paths required by capistrano to install the app.
+
+## Installation
+
+``` bash
+$ ansible-galaxy install crushlovely.capistrano,v1.0.0
+```
+
+## Variables
+
+``` yaml
+app_path: /home/ubuntu/test
+app:
+  user: ubuntu
+  group: ubuntu
+```
+
+## Usage
+
+Once this role is installed on your system, include it in the roles list of your playbook.
+
+``` yaml
+- hosts: localhost
+  roles:
+    - crushlovely.capistrano
+```
+
+## Dependencies
+
+None
+
+## License
+
+MIT

--- a/roles/crushlovely.capistrano/circle.yml
+++ b/roles/crushlovely.capistrano/circle.yml
@@ -1,0 +1,29 @@
+---
+machine:
+  python:
+    version: 2.7.9
+dependencies:
+  pre:
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq python-apt python-pycurl aptitude python-software-properties python-pip python-dev git
+    - sudo apt-get update -qq
+
+    # Install Ansible.
+    - pip install ansible==1.9.0.1
+
+    # Add ansible.cfg to pick up roles path.
+    - "printf '[defaults]\nroles_path = ../' > ansible.cfg"
+test:
+  override:
+    # Get nginx role
+    - ansible-galaxy install -f https://github.com/crushlovely/ansible-capistrano.git,remotes/origin/$CIRCLE_BRANCH -p ./tests/roles/
+
+    # Check the role/playbook's syntax.
+    - ansible-playbook --syntax-check -i tests/inventory tests/test.yml
+
+    # Check the role/playbook's syntax.
+    - ansible-playbook -i tests/inventory tests/test.yml:
+        timeout: 900
+
+    # Idempotence Test
+    - "ansible-playbook -i tests/inventory tests/test.yml | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"

--- a/roles/crushlovely.capistrano/defaults/main.yml
+++ b/roles/crushlovely.capistrano/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+app_path: /home/ubuntu/test
+app_user: ubuntu
+app_group: ubuntu

--- a/roles/crushlovely.capistrano/meta/.galaxy_install_info
+++ b/roles/crushlovely.capistrano/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Wed Dec 16 22:01:21 2015', version: v3.0.0}

--- a/roles/crushlovely.capistrano/meta/main.yml
+++ b/roles/crushlovely.capistrano/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: Pablo Castillo
+  company: Crush & Lovely
+  description: Creates a working directory for a capistrano type deployment
+  license: MIT
+  min_ansible_version: 1.6
+  platforms:
+    - name: Ubuntu
+      versions:
+        - Precise
+        - Trusty
+  categories:
+    - system
+dependencies: []
+version: 2.0.0

--- a/roles/crushlovely.capistrano/tasks/main.yml
+++ b/roles/crushlovely.capistrano/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Create shared directory
+  file: path={{ app_path }}/shared/ state=directory owner={{ app_user }} group={{ app_group }} force=no
+  sudo: yes
+
+- name: Create config directory
+  file: path={{ app_path }}/shared/config/ state=directory owner={{ app_user }} group={{ app_group }} force=no
+  sudo: yes

--- a/roles/crushlovely.capistrano/tests/inventory
+++ b/roles/crushlovely.capistrano/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/crushlovely.capistrano/tests/test.yml
+++ b/roles/crushlovely.capistrano/tests/test.yml
@@ -1,0 +1,7 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  remote_user: ubuntu
+  gather_facts: false
+  roles:
+    - ansible-capistrano


### PR DESCRIPTION
Via ansible-galaxy role crushlovely.capistrano.
Closes #17.
