### PR TITLE
Adds role to install `patch' with yum

### DIFF
--- a/openvault/openvault.yml
+++ b/openvault/openvault.yml
@@ -10,6 +10,8 @@
       sudo: yes
     - role: gcc-c++
       sudo: yes
+    - role: patch
+      sudo: yes
     - role: geerlingguy.ruby
       sudo: yes
       ruby_install_from_source: true

--- a/roles/patch/tasks/main.yml
+++ b/roles/patch/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: install patch with yum
+  yum: name=patch state=installed
+  when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
`patch' is used when installing gem nokogiri 1.6.5, which is part of the
openvault bundle.

closes #39.
